### PR TITLE
Making latitude and longitude coordinates nullable

### DIFF
--- a/Geocoder.php
+++ b/Geocoder.php
@@ -45,12 +45,12 @@ interface Geocoder extends Provider
     /**
      * Reverses geocode given latitude and longitude values.
      *
-     * @param float $latitude
-     * @param float $longitude
+     * @param  float|null  $latitude
+     * @param  float|null  $longitude
      *
      * @return Collection
      *
-     * @throws \Geocoder\Exception\Exception
+     * @throws Exception\Exception
      */
-    public function reverse(float $latitude, float $longitude): Collection;
+    public function reverse(?float $latitude = null, ?float $longitude = null): Collection;
 }

--- a/GeocoderTrait.php
+++ b/GeocoderTrait.php
@@ -37,7 +37,7 @@ trait GeocoderTrait
     /**
      * {@inheritdoc}
      */
-    public function reverse(float $latitude, float $longitude): Collection
+    public function reverse(?float $latitude = null, ?float $longitude = null): Collection
     {
         return $this->reverseQuery(ReverseQuery::fromCoordinates($latitude, $longitude));
     }

--- a/Model/Address.php
+++ b/Model/Address.php
@@ -271,17 +271,13 @@ class Address implements Location
     }
 
     /**
-     * @param float $latitude
-     * @param float $longitude
+     * @param  float|null  $latitude
+     * @param  float|null  $longitude
      *
-     * @return Coordinates|null
+     * @return Coordinates
      */
-    private static function createCoordinates($latitude, $longitude)
+    private static function createCoordinates(?float $latitude = null, ?float $longitude = null): Coordinates
     {
-        if (null === $latitude || null === $longitude) {
-            return null;
-        }
-
         return new Coordinates($latitude, $longitude);
     }
 

--- a/Model/AddressBuilder.php
+++ b/Model/AddressBuilder.php
@@ -148,12 +148,12 @@ final class AddressBuilder
     }
 
     /**
-     * @param float $latitude
-     * @param float $longitude
+     * @param  float|null  $latitude
+     * @param  float|null  $longitude
      *
      * @return AddressBuilder
      */
-    public function setCoordinates($latitude, $longitude): self
+    public function setCoordinates(?float $latitude = null, ?float $longitude = null): self
     {
         try {
             $this->coordinates = new Coordinates($latitude, $longitude);

--- a/Model/Coordinates.php
+++ b/Model/Coordinates.php
@@ -30,22 +30,24 @@ final class Coordinates
     private $longitude;
 
     /**
-     * @param float $latitude
-     * @param float $longitude
+     * @param  float|null  $latitude
+     * @param  float|null  $longitude
      */
-    public function __construct($latitude, $longitude)
+    public function __construct(?float $latitude = null, ?float $longitude = null)
     {
-        Assert::notNull($latitude);
-        Assert::notNull($longitude);
-
-        $latitude = (float) $latitude;
-        $longitude = (float) $longitude;
-
         Assert::latitude($latitude);
         Assert::longitude($longitude);
 
         $this->latitude = $latitude;
         $this->longitude = $longitude;
+    }
+
+    /**
+     * @return bool
+     */
+    public function hasLatitude(): bool
+    {
+        return !is_null($this->latitude);
     }
 
     /**
@@ -55,7 +57,19 @@ final class Coordinates
      */
     public function getLatitude(): float
     {
+        if (is_null($this->latitude)) {
+            throw new \LogicException('Latitude is not set');
+        }
+
         return $this->latitude;
+    }
+
+    /**
+     * @return bool
+     */
+    public function hasLongitude(): bool
+    {
+        return !is_null($this->longitude);
     }
 
     /**
@@ -65,6 +79,10 @@ final class Coordinates
      */
     public function getLongitude(): float
     {
+        if (is_null($this->longitude)) {
+            throw new \LogicException('Longitude is not set');
+        }
+
         return $this->longitude;
     }
 

--- a/ProviderAggregator.php
+++ b/ProviderAggregator.php
@@ -99,7 +99,7 @@ class ProviderAggregator implements Geocoder
     /**
      * {@inheritdoc}
      */
-    public function reverse(float $latitude, float $longitude): Collection
+    public function reverse(?float $latitude = null, ?float $longitude = null): Collection
     {
         return $this->reverseQuery(ReverseQuery::create(new Coordinates($latitude, $longitude))
             ->withLimit($this->limit));

--- a/Query/ReverseQuery.php
+++ b/Query/ReverseQuery.php
@@ -59,12 +59,12 @@ final class ReverseQuery implements Query
     }
 
     /**
-     * @param float $latitude
-     * @param float $longitude
+     * @param  float|null  $latitude
+     * @param  float|null  $longitude
      *
      * @return ReverseQuery
      */
-    public static function fromCoordinates($latitude, $longitude): self
+    public static function fromCoordinates(?float $latitude = null, ?float $longitude = null): self
     {
         return new self(new Coordinates($latitude, $longitude));
     }

--- a/StatefulGeocoder.php
+++ b/StatefulGeocoder.php
@@ -75,7 +75,7 @@ final class StatefulGeocoder implements Geocoder
     /**
      * {@inheritdoc}
      */
-    public function reverse(float $latitude, float $longitude): Collection
+    public function reverse(?float $latitude = null, ?float $longitude = null): Collection
     {
         $query = ReverseQuery::fromCoordinates($latitude, $longitude)
             ->withLimit($this->limit);


### PR DESCRIPTION
This proposed change will allow you to pass nullable arguments to the `Coordinates` class for the values of `$latitude` and `$longitude`.

Through using this library I have found myself every time creating a separate, custom `Coordinates` class that allows for nullable `$latitude` and `$longitude` values. There are many cases where you may wish to still instantiate a `Coordinates` object with one or both values being `null`, and then determining later on if the Coordinates class is usable by calling the `hasLatitude()` or `hasLongitude()` methods.

I am welcome to any and all feedback. This is after all a suggested change, and I won't take offence if it is not accepted.

Cheers! 😄  